### PR TITLE
12 0.1.2 Local checkums insertion into array

### DIFF
--- a/include/rm_rx.h
+++ b/include/rm_rx.h
@@ -19,7 +19,7 @@
 
 /* @brief   Calculates ch_ch structs for all non-overlapping
  *          @L bytes blocks (last one may be less than @L)
- *          from file @f and inserts them into table @h.
+ *          from file @f and inserts them into hashtable @h.
  * @details	File @f MUST be already opened.
  * @param   h - hashtable to store checksums locally (B),
  *          may be NULL, if NULL then do not insert checksums
@@ -33,17 +33,29 @@ rm_rx_insert_nonoverlapping_ch_ch(FILE *f, char *fname,
 		struct twhlist_head *h, uint32_t L,
 		int (*f_tx_ch_ch)(const struct rm_ch_ch *));
 
-/* @brief   Calculates ch_ch_local structs for all non-overlapping
- *          @L bytes blocks (last one may be less than @L)
- *          from file @f and inserts them into list @l.
- * @details	File @f MUST be already opened.
- * @param   l - list to store checksums locally (B), can't be NULL
- * @param   fname - file name, used only for logging
- * @return  On success the number of inserted entries
- *          is returned, -1 on error. */
-long long int
-rm_rx_insert_nonoverlapping_ch_ch_local(FILE *f, char *fname,
-		struct twlist_head *l, uint32_t L);
+/* @brief       Calculates ch_ch structs for all non-overlapping
+ *              @L bytes blocks (last one may be less than @L)
+ *              from file @f and inserts them into array @checkums.
+ * @param       checksums - array of structs rm_ch_ch with size suitable
+ *              to contain all checksums
+ * @blocks_n    on success - set to the number of inserted entries
+ * @return      0 on succes, negative error code on error */
+int
+rm_rx_insert_nonoverlapping_ch_ch_array(FILE *f, const char *fname,
+		struct rm_ch_ch checksums[], uint32_t L,
+		int (*f_tx_ch_ch)(const struct rm_ch_ch *), size_t *blocks_n);
+
+/* @brief       Calculates ch_ch_local structs for all non-overlapping
+ *              @L bytes blocks (last one may be less than @L)
+ *              from file @f and inserts them into list @l.
+ * @details	    File @f MUST be already opened.
+ * @param       l - list to store checksums locally (B), can't be NULL
+ * @param       fname - file name, used only for logging
+ * @blocks_n    on success - set to the number of inserted entries
+ * @return      0 on success, negative error code on error. */
+int
+rm_rx_insert_nonoverlapping_ch_ch_local(FILE *f, const char *fname,
+		struct twlist_head *l, uint32_t L, size_t *blocks_n);
 
 
 #endif	// RSYNCME_RX_H

--- a/src/rm_rx.c
+++ b/src/rm_rx.c
@@ -94,9 +94,79 @@ rm_rx_insert_nonoverlapping_ch_ch(FILE *f, char *fname,
     return	entries_n;
 }
 
-long long int
-rm_rx_insert_nonoverlapping_ch_ch_local(FILE *f, char *fname,
-		struct twlist_head *l, uint32_t L)
+int
+rm_rx_insert_nonoverlapping_ch_ch_array(FILE *f, const char *fname,
+		struct rm_ch_ch checksums[], uint32_t L,
+		int (*f_tx_ch_ch)(const struct rm_ch_ch *), size_t *blocks_n)
+{
+    int         fd, res;
+    struct stat fs;
+    uint32_t	file_sz, read_left, read_now, read;
+    long long int	entries_n;
+    struct rm_ch_ch	*e;
+    unsigned char	*buf;
+
+    assert(f != NULL);
+    assert(fname != NULL);
+    assert(L > 0);
+
+    /* get file size */
+    fd = fileno(f);
+    res = fstat(fd, &fs);
+    if (res != 0)
+    {
+        RM_LOG_PERR("Can't fstat file [%s]", fname);
+        return -1;
+    }
+    file_sz = fs.st_size;
+
+    /* read L bytes chunks */
+    read_left = file_sz;
+    read_now = rm_min(L, read_left);
+    buf = malloc(read_now);
+    if (buf == NULL)
+    {
+        RM_LOG_ERR("Malloc failed, L [%u], "
+                "read_now [%u]", L, read_now);
+        return -2;
+    }
+
+    entries_n = 0;
+    do
+    {
+        read = fread(buf, 1, read_now, f);
+        if (read != read_now)
+        {
+            RM_LOG_PERR("Error reading file [%s]", fname);
+            free(buf);
+            return -3;
+        }
+
+        /* compute checksums */
+        e = &checksums[entries_n];
+        e->f_ch = rm_fast_check_block(buf, read);
+        rm_md5(buf, read, e->s_ch.data);
+
+        entries_n++;
+
+        /* tx checksums to remote A ? */
+        if (f_tx_ch_ch != NULL)
+        {
+            res = f_tx_ch_ch(e);
+            if (res < 0)
+                return -5;
+        }
+        read_left -= read;
+        read_now = rm_min(L, read_left);
+    } while (read_now > 0);
+
+    *blocks_n = entries_n;
+    return 0;
+}
+
+int
+rm_rx_insert_nonoverlapping_ch_ch_local(FILE *f, const char *fname,
+		struct twlist_head *l, uint32_t L, size_t *blocks_n)
 {
     int         fd, res;
     struct stat fs;
@@ -165,5 +235,6 @@ rm_rx_insert_nonoverlapping_ch_ch_local(FILE *f, char *fname,
         read_now = rm_min(L, read_left);
     } while (read_now > 0);
 
-    return	entries_n;
+    *blocks_n = entries_n;
+    return	0;
 }


### PR DESCRIPTION
Now rm_ch_ch structs are inserted into array
so they can be accessed in O(1) later while
reconstructing file from delta vector.