### PR TITLE
0.1.3 Configure automated build to execute on BUILD_BRANCH

### DIFF
--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -12,6 +12,7 @@ pipelines:
           - apt-get --force-yes --yes install cmake
           - rm -rf rsyncme
           - git clone --recursive https://bitbucket.org/piotrgregor/rsyncme.git
+          - git checkout $BUILD_BRANCH
           - cd rsyncme/src
           - cd ../ && bash ./pip_install_deps.sh cmocka && cd src
           - make


### PR DESCRIPTION
Now we will always build on current branch (remember
to set BUILD_BRANCH to desired value before build starts!).
BUILD_BRANCH is bitbucket pipelines variable configured
via web interface to pipelines settings.