### PR TITLE
0.1.3 325 [delta protocol] Implement delta TX

### DIFF
--- a/include/rm_defs.h
+++ b/include/rm_defs.h
@@ -93,6 +93,10 @@
 #define RM_NANOSEC_PER_SEC          1000000000U
 #define RM_CORE_HASH_CHALLENGE_BITS 32u
 
+#define RM_DELTA_ELEMENT_TYPE_FIELD_SIZE	1	/* we need 2 bits to be honest */
+#define RM_DELTA_ELEMENT_BYTES_FIELD_SIZE	8	/* it is size_t now, but we will change it to be uint64_t explicitly */
+#define RM_DELTA_ELEMENT_REF_FIELD_SIZE		8	/* it is size_t now, but we will change it to be uint64_t explicitly */
+
 /* defaults */
 #define RM_DEFAULT_L                512         /* default block size in bytes */
 #define RM_L1_CACHE_RECOMMENDED     8192        /* buffer size, so that it should fit into

--- a/src/rm_session.c
+++ b/src/rm_session.c
@@ -657,7 +657,7 @@ void* rm_session_delta_rx_f_remote(void *arg)
 	assert(prvt_rx != NULL);
 
 	pthread_mutex_lock(&s->mutex);
-	bytes_to_rx = s->f_x_sz;
+	bytes_to_rx = prvt_rx->msg_push->bytes;
 	/* f_y         = prvt_rx->f_y; */
 	pthread_mutex_unlock(&s->mutex);
 


### PR DESCRIPTION
Implement rm_rx_tx_delta_element to TX delta over TCP using DELTA protocol
PROTOCOL
Currently protocol is simple:
1.   TX delta type
2.   If it is DELTA_REFERENCE || DELTA_TAIL
         then TX ref
     else if it is DELTA_RAW_BYTES
         then    TX bytes size,
                 TX bytes
     else
         it is DELTA_ZERO_DIFF, do not TX anything, we are done