### PR TITLE
0.1.3-alpha 357 358 #fix memory leaks

### DIFF
--- a/include/rm_core.h
+++ b/include/rm_core.h
@@ -68,6 +68,8 @@ struct rm_session* rm_core_session_find(struct rsyncme *rm, unsigned char sessio
 
 /* @brief   Adds new sesion into table and list. */
 void rm_core_session_add(struct rsyncme *rm, struct rm_session *s) __attribute__ ((nonnull(1,2)));
+/* @brief   Remove sesion from table and list. */
+void rm_core_session_del(struct rsyncme *rm, struct rm_session *s) __attribute__ ((nonnull(1,2)));
 
 /* @brief   Shut down. */
 int rm_core_shutdown(struct rsyncme *rm) __attribute__ ((nonnull(1)));

--- a/src/rm_core.c
+++ b/src/rm_core.c
@@ -86,13 +86,13 @@ void rm_core_session_add(struct rsyncme *rm, struct rm_session *s)
 	return;
 }
 
-	int
-rm_core_session_stop(struct rm_session *s)
+void rm_core_session_del(struct rsyncme *rm, struct rm_session *s)
 {
 	assert(s != NULL);
+	pthread_mutex_lock(&rm->mutex);
 	twlist_del(&s->link);
 	twhash_del(&s->hlink);
-	return 0;
+	pthread_mutex_unlock(&rm->mutex);
 }
 
 enum rm_error rm_core_authenticate(struct sockaddr_in *cli_addr)

--- a/src/rm_do_msg.c
+++ b/src/rm_do_msg.c
@@ -209,6 +209,7 @@ void* rm_do_msg_push_rx(void* arg) {
 	RM_LOG_INFO("[%s] [11]: [%s] -> [%s], Session [%u][%u] ended", rm_work_type_str[work->task], s->ssid1, s->ssid2, s->hash, s->hashed_hash);
 
 	if (s != NULL) {
+		rm_core_session_del(work->rm, s);
 		rm_session_free(s);																					/* frees msg allocated for work as well */
 		s = NULL;
 		work->msg = NULL;																					/* do not free msg again in work dtor */
@@ -304,6 +305,7 @@ fail:
 		/* TODO reschedule the job? */
 	}
 	if (s != NULL) {
+		rm_core_session_del(work->rm, s);
 		rm_session_free(s);
 		s = NULL;
 		work->msg = NULL;																					/* do not free msg again in work dtor */
@@ -399,8 +401,7 @@ rm_calc_msg_len(void *arg) {
 	return len;
 }
 
-void
-rm_msg_push_dtor(void *arg) {
+void rm_msg_push_dtor(void *arg) {
 	struct rm_work *work = (struct rm_work*) arg;
 	close(work->fd);
 	if (work->msg)


### PR DESCRIPTION
Added removal of session from global hashtable in rm_do_msg_push_rx().
No known memory leaks exist now. Valgrind is quiet.

-------------- process 1 ---------------
peter@westernst:~/projects/rsyncme/build/debug$ valgrind --leak-check=yes --leak-check=full --show-leak-kinds=all ./rsyncme_d
==31107== Memcheck, a memory error detector
==31107== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.
==31107== Using Valgrind-3.10.0 and LibVEX; rerun with -h for copyright info
==31107== Command: ./rsyncme_d
==31107==
-------------- process 2 ---------------
peter@westernst:~/test/rsyncme$ rsyncme push -x /home/peter/test/rsyncme/test13.txt -y /home/peter/test/rsyncme/test15.txt -z /home/peter/test/rsyncme/test16.txt -i localhost --lea

Remote push.

method      : DELTA_RECONSTRUCTION (block [512])
bytes       : [6] (by raw [6], by refs [0])
              checksums             : [1]
              deltas                : [1] (raw [1], refs [0])
              checksums overhead    : [20]
              deltas overhead       : raw [9], refs [0]
              Total TX overhead     : [9]
              Total TX              : [33]
collisions  : 1st [0], 2nd [0], 3rd [0]
time        : real [0.002751]s, cpu [0.001536]s
bandwidth   : [0.002181]MB/s (virtual)
bandwidth   : [0.011997]MB/s (real)

improvement : [-4.500000]

-------------- process 1 ---------------
^C
^Z==31107==
==31107== HEAP SUMMARY:
==31107==     in use at exit: 0 bytes in 0 blocks
==31107==   total heap usage: 70 allocs, 70 frees, 102,050 bytes allocated
==31107==
==31107== All heap blocks were freed -- no leaks are possible
==31107==
==31107== For counts of detected and suppressed errors, rerun with: -v
==31107== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 2 from 1)
peter@westernst:~/projects/rsyncme/build/debug$

========================================

receiver's log:

94 2017-07-22_21-40-03:544510  INFO    rm_daemon.c:161:do_it_all():    core: Incoming connection, peer [127.0.0.1] port [59428], handled on local interface [127.0.0.1] port [5048]
 95 2017-07-22_21-40-03:544595  INFO    rm_daemon.c:185:do_it_all():    core: Waiting for incoming header from peer [127.0.0.1] port [59428], on local interface [127.0.0.1] port [5048]
 96 2017-07-22_21-40-03:544653  INFO    rm_daemon.c:200:do_it_all():    core: Validating header from peer [127.0.0.1] port [59428]
 97 2017-07-22_21-40-03:544721  INFO    rm_daemon.c:240:do_it_all():    core: Enqueuing MSG_PUSH work from peer [127.0.0.1] port [59428]
 98 2017-07-22_21-40-03:544807  INFO    rm_do_msg.c:69:rm_do_msg_push_rx(): [RM_WORK_PROCESS_MSG_PUSH] [0]: work started in worker [2] thread [144733952]
 99 2017-07-22_21-40-03:544991  INFO    rm_do_msg.c:87:rm_do_msg_push_rx(): [RM_WORK_PROCESS_MSG_PUSH] [1]: their ssid [d5f901e9-3e25-4143-a06e-ef3250a81ffe] -> our ssid [417a7363-6ae8-4edf-8556-76ff80ac93ad]
100 2017-07-22_21-40-03:545036  INFO    rm_do_msg.c:89:rm_do_msg_push_rx(): [RM_WORK_PROCESS_MSG_PUSH] [2]: [d5f901e9-3e25-4143-a06e-ef3250a81ffe] -> [417a7363-6ae8-4edf-8556-76ff80ac93ad], x [/home/peter/test/rsyncme/test13.txt], y [/home/peter/test/rsyncme/test15.txt], z [/home/peter/test/rsyncme/test16.txt], L [512], flags [110][0x6e]. Validating...
101 2017-07-22_21-40-03:545268  INFO    rm_do_msg.c:93:rm_do_msg_push_rx(): [RM_WORK_PROCESS_MSG_PUSH] [2]: [d5f901e9-3e25-4143-a06e-ef3250a81ffe] -> [417a7363-6ae8-4edf-8556-76ff80ac93ad], --leave
102 2017-07-22_21-40-03:546456  INFO    rm_do_msg.c:104:rm_do_msg_push_rx():    [RM_WORK_PROCESS_MSG_PUSH] [3]: [d5f901e9-3e25-4143-a06e-ef3250a81ffe] -> [417a7363-6ae8-4edf-8556-76ff80ac93ad], Opening ephemeral delta rx port
103 2017-07-22_21-40-03:546523  INFO    rm_do_msg.c:115:rm_do_msg_push_rx():    [RM_WORK_PROCESS_MSG_PUSH] [4]: [d5f901e9-3e25-4143-a06e-ef3250a81ffe] -> [417a7363-6ae8-4edf-8556-76ff80ac93ad], x [/home/peter/test/rsyncme/test13.txt], y [/home/peter/test/rsyncme/test15.txt], z [/home/peter/test/rsyncme/test16.txt], L [512], flags [0x6e], tmp [778112f1-2610-4eb5-ae7a-5ed310af125a    ], listening on delta rx port [33764]
104 2017-07-22_21-40-03:546596  INFO    rm_do_msg.c:122:rm_do_msg_push_rx():    [RM_WORK_PROCESS_MSG_PUSH] [5]: [d5f901e9-3e25-4143-a06e-ef3250a81ffe] -> [417a7363-6ae8-4edf-8556-76ff80ac93ad], TXed ACK
105 2017-07-22_21-40-03:546643  INFO    rm_do_msg.c:126:rm_do_msg_push_rx():    [RM_WORK_PROCESS_MSG_PUSH] [6]: [d5f901e9-3e25-4143-a06e-ef3250a81ffe] -> [417a7363-6ae8-4edf-8556-76ff80ac93ad], Session hashed to [3676005012][689446071]
106 2017-07-22_21-40-03:546736  INFO    rm_do_msg.c:133:rm_do_msg_push_rx():    [RM_WORK_PROCESS_MSG_PUSH] [7]: [d5f901e9-3e25-4143-a06e-ef3250a81ffe] -> [417a7363-6ae8-4edf-8556-76ff80ac93ad], Checksums tx thread started
107 2017-07-22_21-40-03:546803  INFO    rm_do_msg.c:140:rm_do_msg_push_rx():    [RM_WORK_PROCESS_MSG_PUSH] [8]: [d5f901e9-3e25-4143-a06e-ef3250a81ffe] -> [417a7363-6ae8-4edf-8556-76ff80ac93ad], Delta rx thread started
108 2017-07-22_21-40-03:547075  INFO    rm_do_msg.c:144:rm_do_msg_push_rx():    [RM_WORK_PROCESS_MSG_PUSH] [9]: [d5f901e9-3e25-4143-a06e-ef3250a81ffe] -> [417a7363-6ae8-4edf-8556-76ff80ac93ad], Checksums tx thread joined
109 2017-07-22_21-40-03:547129  INFO    rm_do_msg.c:148:rm_do_msg_push_rx():    [RM_WORK_PROCESS_MSG_PUSH] [10]: [d5f901e9-3e25-4143-a06e-ef3250a81ffe] -> [417a7363-6ae8-4edf-8556-76ff80ac93ad], All threads joined
110
111 method      : DELTA_RECONSTRUCTION (block [512])
112 bytes       : [6] (by raw [6], by refs [0])
113               checksums             : [1]
114               deltas                : [1] (raw [1], refs [0])
115               checksums overhead    : [20]
116               deltas overhead       : raw [9], refs [0]
117               Total RX overhead     : [9]
118               Total RX              : [33]
119 time        : real [0.002096]s, cpu [0.625724]s
120 bandwidth   : [0.002862]MB/s (virtual)
121 bandwidth   : [0.015742]MB/s (real)
122
123 improvement : [-4.500000]
124 2017-07-22_21-40-03:547322  INFO    rm_do_msg.c:209:rm_do_msg_push_rx():    [RM_WORK_PROCESS_MSG_PUSH] [11]: [d5f901e9-3e25-4143-a06e-ef3250a81ffe] -> [417a7363-6ae8-4edf-8556-76ff80ac93ad], Session [3676005012][689446071] ended
125 2017-07-22_21-41-44:887851  ERR     rm_daemon.c:517:main(): core: Accept interrupted, Interrupted system call
126
127
128 ==Received SIGINT==
129
130 State:
131 sessions_n                              [4]
132 workers_n                               [8]
133 workers_active_n                        [8]
134
135
136 2017-07-22_21-43-00:543330  ERR     rm_daemon.c:517:main(): core: Accept interrupted, Interrupted system call
137
138
139 ==Received SIGTSTP==
140
141 Quiting...
142
143
144 2017-07-22_21-43-00:543773  INFO    rm_daemon.c:531:main(): core: Shutdown
145 2017-07-22_21-43-00:544653  INFO    rm_core.c:39:rm_core_deinit():  Stopping main work queue